### PR TITLE
Add Privacy Policy from Termly

### DIFF
--- a/docs/about/privacy.md
+++ b/docs/about/privacy.md
@@ -1,0 +1,331 @@
+# PRIVACY POLICY
+
+Last updated July 11, 2025
+
+This Privacy Notice for Custcodian LLC ("<strong>we</strong>," "<strong>us</strong>," or "<strong>our</strong>"), describes how and why we might access, collect, store, use, and/or share ("<strong>process</strong>") your personal information when you use our services ("<strong>Services</strong>"), including when you:
+
+* Visit our website at https://custcodian.dev/ or any website of ours that links to this Privacy Notice
+* Download and use our client application (Minder) or any other application of ours that links to this Privacy Notice
+* Enable Minder to manage your software assets on a third-party site
+* Engage with us in other related ways, including any sales, marketing, or events
+
+**Questions or concerns?** Reading this Privacy Notice will help you understand your privacy rights and choices. We are responsible for making decisions about how your personal information is processed. If you do not agree with our policies and practices, please do not use our Services. If you still have any questions or concerns, please contact us at privacy@custcodian.dev.
+
+## SUMMARY OF KEY POINTS
+
+<strong><em>This summary provides key points from our Privacy Notice, but you can find out more details about any of these topics by clicking the link following each key point or by using our [table of contents](#table-of-contents below to find the section you are looking for.</em></strong>
+
+<strong>What personal information do we process?</strong> When you visit, use, or navigate our Services, we may process personal information depending on how you interact with us and the Services, the choices you make, and the products and features you use. Learn more about [personal information you disclose to us](#personal-information-you-disclose-to-us.
+
+<strong>Do we process any sensitive personal information?</strong> Some of the information may be considered "special" or "sensitive" in certain jurisdictions, for example your racial or ethnic origins, sexual orientation, and religious beliefs. We do not process sensitive personal information.
+
+<strong>Do we collect any information from third parties?</strong> We do not collect any information from third parties.
+
+<strong>How do we process your information?</strong> We process your information to provide, improve, and administer our Services, communicate with you, for security and fraud prevention, and to comply with law. We may also process your information for other purposes with your consent. We process your information only when we have a valid legal reason to do so. Learn more about [how we process your information](#2-how-do-we-process-your-information).
+
+<strong>In what situations and with which parties do we share personal information?</strong> We may share information in specific situations and with specific third parties. Learn more about [when and with whom we share your personal information](#4-when-and-with-whom-do-we-share-your-personal-information).
+
+<strong>How do we keep your information safe?</strong> We have adequate organizational and technical processes and procedures in place to protect your personal information. However, no electronic transmission over the internet or information storage technology can be guaranteed to be 100% secure, so we cannot promise or guarantee that hackers, cybercriminals, or other unauthorized third parties will not be able to defeat our security and improperly collect, access, steal, or modify your information. Learn more about [how we keep your information safe](#8-how-do-we-keep-your-information-safe).
+
+<strong>What are your rights?</strong> Depending on where you are located geographically, the applicable privacy law may mean you have certain rights regarding your personal information. Learn more about [your privacy rights](#10-what-are-your-privacy-rights).
+
+<strong>How do you exercise your rights?</strong> The easiest way to exercise your rights is by visiting <a href="https://custcodian.dev/about/" target="_blank">https://custcodian.dev/about/</a>, or by contacting us. We will consider and act upon any request in accordance with applicable data protection laws.
+
+Want to learn more about what we do with any information we collect? [Review the Privacy Notice in full](#table-of-contents).
+
+## TABLE OF CONTENTS
+1. [WHAT INFORMATION DO WE COLLECT?](#1-what-information-do-we-collect)
+2. [HOW DO WE PROCESS YOUR INFORMATION?](#2-how-do-we-process-your-information)
+3. [WHAT LEGAL BASES DO WE RELY ON TO PROCESS YOUR PERSONAL INFORMATION?](#3-what-legal-bases-do-we-rely-on-to-process-your-information)
+4. [WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?](#4-when-and-with-whom-do-we-share-your-personal-information)
+5. [HOW DO WE HANDLE YOUR SOCIAL LOGINS?](#5-how-do-we-handle-your-social-logins)
+6. [IS YOUR INFORMATION TRANSFERRED INTERNATIONALLY?](#6-is-your-information-transferred-internationally)
+7. [HOW LONG DO WE KEEP YOUR INFORMATION?](#7-how-long-do-we-keep-your-information)
+8. [HOW DO WE KEEP YOUR INFORMATION SAFE?](#8-how-do-we-keep-your-information-safe)
+9. [DO WE COLLECT INFORMATION FROM MINORS?](#9-do-we-collect-information-from-minors)
+10. [WHAT ARE YOUR PRIVACY RIGHTS?](#10-what-are-your-privacy-rights)
+11. [CONTROLS FOR DO-NOT-TRACK FEATURES](#11-controls-for-do-not-track-features)
+12. [DO UNITED STATES RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?](#12-do-united-states-residents-have-specific-privacy-rights)
+13. [DO WE MAKE UPDATES TO THIS NOTICE?](#13-do-we-make-updates-to-this-notice)
+14. [HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](#14-how-can-you-contact-us-about-this-notice)
+15. [HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?](#15-how-can-you-review-update-or-delete-the-data-we-collect-from-you)
+
+## 1. WHAT INFORMATION DO WE COLLECT?
+
+### Personal information you disclose to us
+<em><strong>In Short:</strong> We collect personal information that you provide to us.</em>
+
+We collect personal information that you voluntarily provide to us when you register on the Services, express an interest in obtaining information about us or our products and Services, when you participate in activities on the Services, or otherwise when you contact us.
+
+<strong>Personal Information Provided by You.</strong> The personal information that we collect depends on the context of your interactions with us and the Services, the choices you make, and the products and features you use. The personal information we collect may include the following:
+
+* email addresses
+* usernames
+* contact or authentication data
+* names
+
+<strong>Sensitive Information.</strong> We do not process sensitive information.
+
+<strong>Social Media Login Data.</strong> We may provide you with the option to register with us using your existing social media account details, like your GitHub, Google, or other social media account. If you choose to register in this way, we will collect certain profile information about you from the social media provider, as described in the section called "[HOW DO WE HANDLE YOUR SOCIAL LOGINS?](#5-how-do-we-handle-your-social-logins)" below.
+
+All personal information that you provide to us must be true, complete, and accurate, and you must notify us of any changes to such personal information.
+
+### Information automatically collected
+
+<em><strong>In Short:</strong> Some information — such as your Internet Protocol (IP) address and/or browser and device characteristics — is collected automatically when you visit our Services.</em>
+
+We automatically collect certain information when you visit, use, or navigate the Services. This information does not reveal your specific identity (like your name or contact information) but may include device and usage information, such as your IP address, browser and device characteristics, operating system, language preferences, referring URLs, device name, country, location, information about how and when you use our Services, and other technical information. This information is primarily needed to maintain the security and operation of our Services, and for our internal analytics and reporting purposes.
+
+The information we collect includes:
+* <em>Log and Usage Data.</em> Log and usage data is service-related, diagnostic, usage, and performance information our servers automatically collect when you access or use our Services and which we record in log files. Depending on how you interact with us, this log data may include your IP address, device information, browser type, and settings and information about your activity in the Services (such as the date/time stamps associated with your usage, pages and files viewed, searches, and other actions you take such as which features you use), device event information (such as system activity, error reports (sometimes called "crash dumps"), and hardware settings).
+
+## 2. HOW DO WE PROCESS YOUR INFORMATION?
+
+<em><strong>In Short: </strong>We process your information to provide, improve, and administer our Services, communicate with you, for security and fraud prevention, and to comply with law. We process the personal information for the following purposes listed below. We may also process your information for other purposes only with your prior explicit consent.</em>
+
+<strong>We process your personal information for a variety of reasons, depending on how you interact with our Services, including:</strong>
+
+* <strong>To facilitate account creation and authentication and otherwise manage user accounts.</strong> We may process your information so you can create and log in to your account, as well as keep your account in working order.
+* <strong>To deliver and facilitate delivery of services to the user.</strong> We may process your information to provide you with the requested service.
+* <strong>To send administrative information to you.</strong> We may process your information to send you details about our products and services, changes to our terms and policies, and other similar information.
+* <strong>To request feedback.</strong> We may process your information when necessary to request feedback and to contact you about your use of our Services.
+* <strong>To protect our Services.</strong> We may process your information as part of our efforts to keep our Services safe and secure, including fraud monitoring and prevention.
+* <strong>To identify usage trends.</strong> We may process information about how you use our Services to better understand how they are being used so we can improve them.
+* <strong>To save or protect an individual's vital interest.</strong> We may process your information when necessary to save or protect an individual’s vital interest, such as to prevent harm.
+
+## 3. WHAT LEGAL BASES DO WE RELY ON TO PROCESS YOUR INFORMATION?
+
+<em><strong>In Short:</strong> We only process your personal information when we believe it is necessary and we have a valid legal reason (i.e., legal basis) to do so under applicable law, like with your consent, to comply with laws, to provide you with services to enter into or fulfill our contractual obligations, to protect your rights, or to fulfill our legitimate business interests.</em>
+
+<em><strong><u>If you are located in the EU or UK, this section applies to you.</u></strong></em>
+
+The General Data Protection Regulation (GDPR) and UK GDPR require us to explain the valid legal bases we rely on in order to process your personal information. As such, we may rely on the following legal bases to process your personal information:
+
+* <strong>Consent.</strong> We may process your information if you have given us permission (i.e., consent) to use your personal information for a specific purpose. You can withdraw your consent at any time. Learn more about [withdrawing your consent](#withdrawconsent).
+* <strong>Performance of a Contract.</strong> We may process your personal information when we believe it is necessary to fulfill our contractual obligations to you, including providing our Services or at your request prior to entering into a contract with you.
+* <strong>Legitimate Interests.</strong> We may process your information when we believe it is reasonably necessary to achieve our legitimate business interests and those interests do not outweigh your interests and fundamental rights and freedoms. For example, we may process your personal information for some of the purposes described in order to:
+   * Analyze how our Services are used so we can improve them to engage and retain users
+   * Diagnose problems and/or prevent fraudulent activities
+   * Understand how our users use our products and services so we can improve user experience
+
+* <strong>Legal Obligations.</strong> We may process your information where we believe it is necessary for compliance with our legal obligations, such as to cooperate with a law enforcement body or regulatory agency, exercise or defend our legal rights, or disclose your information as evidence in litigation in which we are involved.
+
+* <strong>Vital Interests.</strong> We may process your information where we believe it is necessary to protect your vital interests or the vital interests of a third party, such as situations involving potential threats to the safety of any person.
+
+<strong><u><em>If you are located in Canada, this section applies to you.</em></u></strong>
+
+We may process your information if you have given us specific permission (i.e., express consent) to use your personal information for a specific purpose, or in situations where your permission can be inferred (i.e., implied consent). You can [withdraw your consent](#withdrawconsent) at any time.
+
+In some exceptional cases, we may be legally permitted under applicable law to process your information without your consent, including, for example:
+
+* If collection is clearly in the interests of an individual and consent cannot be obtained in a timely way
+* For investigations and fraud detection and prevention
+* For business transactions provided certain conditions are met
+* If it is contained in a witness statement and the collection is necessary to assess, process, or settle an insurance claim
+* For identifying injured, ill, or deceased persons and communicating with next of kin
+* If we have reasonable grounds to believe an individual has been, is, or may be victim of financial abuse
+* If it is reasonable to expect collection and use with consent would compromise the availability or the accuracy of the information and the collection is reasonable for purposes related to investigating a breach of an agreement or a contravention of the laws of Canada or a province
+* If disclosure is required to comply with a subpoena, warrant, court order, or rules of the court relating to the production of records
+* If it was produced by an individual in the course of their employment, business, or profession and the collection is consistent with the purposes for which the information was produced
+* If the collection is solely for journalistic, artistic, or literary purposes
+* If the information is publicly available and is specified by the regulations
+* We may disclose de-identified information for approved research or statistics projects, subject to ethics oversight and confidentiality commitments
+
+## 4. WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?
+
+<em><strong>In Short:</strong> We may share information in specific situations described in this section and/or with the following third parties.</em>
+
+We may need to share your personal information in the following situations:
+
+* <strong>Business Transfers.</strong> We may share or transfer your information in connection with, or during negotiations of, any merger, sale of company assets, financing, or acquisition of all or a portion of our business to another company.
+
+## 5. HOW DO WE HANDLE YOUR SOCIAL LOGINS?
+
+<em><strong>In Short:</strong> If you choose to register or log in to our Services using a social media account, we may have access to certain information about you.</em>
+
+Our Services offer you the ability to register and log in using your third-party social media account details (like your Facebook or X logins). Where you choose to do this, we will receive certain profile information about you from your social media provider. The profile information we receive may vary depending on the social media provider concerned, but will often include your name, email address, friends list, and profile picture, as well as other information you choose to make public on such a social media platform.
+
+We will use the information we receive only for the purposes that are described in this Privacy Notice or that are otherwise made clear to you on the relevant Services. Please note that we do not control, and are not responsible for, other uses of your personal information by your third-party social media provider. We recommend that you review their privacy notice to understand how they collect, use, and share your personal information, and how you can set your privacy preferences on their sites and apps.
+
+## 6. IS YOUR INFORMATION TRANSFERRED INTERNATIONALLY?
+
+<em><strong>In Short:</strong> We may transfer, store, and process your information in countries other than your own.</em>
+
+Our servers are located in the United States. If you are accessing our Services from outside the United States, please be aware that your information may be transferred to, stored by, and processed by us in our facilities and in the facilities of the third parties with whom we may share your personal information (see "[WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?](#4-when-and-with-whom-do-we-share-your-personal-information)" above), and in other countries.
+
+If you are a resident in the European Economic Area (EEA), United Kingdom (UK), or Switzerland, then these countries may not necessarily have data protection laws or other similar laws as comprehensive as those in your country. However, we will take all necessary measures to protect your personal information in accordance with this Privacy Notice and applicable law.
+
+European Commission's Standard Contractual Clauses:
+
+We have implemented measures to protect your personal information, including by using the European Commission's Standard Contractual Clauses for transfers of personal information between our group companies and between us and our third-party providers. These clauses require all recipients to protect all personal information that they process originating from the EEA or UK in accordance with European data protection laws and regulations.
+ 
+Our Standard Contractual Clauses can be provided upon request.
+ 
+We have implemented similar appropriate safeguards with our third-party service providers and partners and further details can be provided upon request.
+
+# 7. HOW LONG DO WE KEEP YOUR INFORMATION?
+<em><strong>In Short:</strong> We keep your information for as long as necessary to fulfill the purposes outlined in this Privacy Notice unless otherwise required by law.</em>
+
+We will only keep your personal information for as long as it is necessary for the purposes set out in this Privacy Notice, unless a longer retention period is required or permitted by law (such as tax, accounting, or other legal requirements). No purpose in this notice will require us keeping your personal information for longer than three (3) months past the termination of the user's account.
+
+When we have no ongoing legitimate business need to process your personal information, we will either delete or anonymize such information, or, if this is not possible (for example, because your personal information has been stored in backup archives), then we will securely store your personal information and isolate it from any further processing until deletion is possible.
+
+## 8. HOW DO WE KEEP YOUR INFORMATION SAFE?
+
+<em><strong>In Short: </strong>We aim to protect your personal information through a system of organizational and technical security measures.</em>
+
+We have implemented appropriate and reasonable technical and organizational security measures designed to protect the security of any personal information we process. However, despite our safeguards and efforts to secure your information, no electronic transmission over the Internet or information storage technology can be guaranteed to be 100% secure, so we cannot promise or guarantee that hackers, cybercriminals, or other unauthorized third parties will not be able to defeat our security and improperly collect, access, steal, or modify your information. Although we will do our best to protect your personal information, transmission of personal information to and from our Services is at your own risk. You should only access the Services within a secure environment.
+
+## 9. DO WE COLLECT INFORMATION FROM MINORS?
+
+<em><strong>In Short:</strong> We do not knowingly collect data from or market to children under 18 years of age or the equivalent age as specified by law in your jurisdiction.</em>
+
+We do not knowingly collect, solicit data from, or market to children under 18 years of age or the equivalent age as specified by law in your jurisdiction, nor do we knowingly sell such personal information. By using the Services, you represent that you are at least 18 or the equivalent age as specified by law in your jurisdiction or that you are the parent or guardian of such a minor and consent to such minor dependent’s use of the Services. If we learn that personal information from users less than 18 years of age or the equivalent age as specified by law in your jurisdiction has been collected, we will deactivate the account and take reasonable measures to promptly delete such data from our records. If you become aware of any data we may have collected from children under age 18 or the equivalent age as specified by law in your jurisdiction, please contact us at privacy@custcodian.dev.
+
+## 10. WHAT ARE YOUR PRIVACY RIGHTS?
+
+<em><strong>In Short:</strong> Depending on your state of residence in the US or in some regions, such as the European Economic Area (EEA), United Kingdom (UK), Switzerland, and Canada, you have rights that allow you greater access to and control over your personal information. You may review, change, or terminate your account at any time, depending on your country, province, or state of residence.</em>
+
+In some regions (like the EEA, UK, Switzerland, and Canada), you have certain rights under applicable data protection laws. These may include the right (i) to request access and obtain a copy of your personal information, (ii) to request rectification or erasure; (iii) to restrict the processing of your personal information; (iv) if applicable, to data portability; and (v) not to be subject to automated decision-making. If a decision that produces legal or similarly significant effects is made solely by automated means, we will inform you, explain the main factors, and offer a simple way to request human review. In certain circumstances, you may also have the right to object to the processing of your personal information. You can make such a request by contacting us by using the contact details provided in the section "[HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](#14-how-can-you-contact-us-about-this-notice)" below.
+
+We will consider and act upon any request in accordance with applicable data protection laws.
+
+If you are located in the EEA or UK and you believe we are unlawfully processing your personal information, you also have the right to complain to your <a href="https://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm" rel="noopener noreferrer" target="_blank">Member State data protection authority</a> or <a href="https://ico.org.uk/make-a-complaint/data-protection-complaints/data-protection-complaints/" rel="noopener noreferrer" target="_blank">UK data protection authority</a>.
+
+If you are located in Switzerland, you may contact the <a href="https://www.edoeb.admin.ch/edoeb/en/home.html" rel="noopener noreferrer" target="_blank">Federal Data Protection and Information Commissioner</a>.
+
+<strong><u><a name="withdrawconsent">Withdrawing your consent:</a></u></strong> If we are relying on your consent to process your personal information, which may be express and/or implied consent depending on the applicable law, you have the right to withdraw your consent at any time. You can withdraw your consent at any time by contacting us by using the contact details provided in the section "[HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](#14-how-can-you-contact-us-about-this-notice)" below or updating your preferences.
+
+However, please note that this will not affect the lawfulness of the processing before its withdrawal nor, when applicable law allows, will it affect the processing of your personal information conducted in reliance on lawful processing grounds other than consent.
+
+### Account Information
+
+If you would at any time like to review or change the information in your account or terminate your account, you can:
+
+* Log in to your account settings and update your user account.
+
+Upon your request to terminate your account, we will deactivate or delete your account and information from our active databases. However, we may retain some information in our files to prevent fraud, troubleshoot problems, assist with any investigations, enforce our legal terms and/or comply with applicable legal requirements.
+
+If you have questions or comments about your privacy rights, you may email us at privacy@custcodian.dev.
+
+## 11. CONTROLS FOR DO-NOT-TRACK FEATURES
+
+Most web browsers and some mobile operating systems and mobile applications include a Do-Not-Track ("DNT") feature or setting you can activate to signal your privacy preference not to have data about your online browsing activities monitored and collected. At this stage, no uniform technology standard for recognizing and implementing DNT signals has been finalized. As such, we do not currently respond to DNT browser signals or any other mechanism that automatically communicates your choice not to be tracked online. If a standard for online tracking is adopted that we must follow in the future, we will inform you about that practice in a revised version of this Privacy Notice.
+
+California law requires us to let you know how we respond to web browser DNT signals. Because there currently is not an industry or legal standard for recognizing or honoring DNT signals, we do not respond to them at this time.
+
+## 12. DO UNITED STATES RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?
+
+<em><strong>In Short: </strong>If you are a resident of California, Colorado, Connecticut, Delaware, Florida, Indiana, Iowa, Kentucky, Maryland, Minnesota, Montana, Nebraska, New Hampshire, New Jersey, Oregon, Rhode Island, Tennessee, Texas, Utah, or Virginia, you may have the right to request access to and receive details about the personal information we maintain about you and how we have processed it, correct inaccuracies, get a copy of, or delete your personal information. You may also have the right to withdraw your consent to our processing of your personal information. These rights may be limited in some circumstances by applicable law. More information is provided below.</em>
+
+### Categories of Personal Information We Collect
+
+</strong>The table below shows the categories of personal information we have collected in the past twelve (12) months. The table includes illustrative examples of each category and does not reflect the personal information we collect from you. For a comprehensive inventory of all personal information we process, please refer to the section "[WHAT INFORMATION DO WE COLLECT?](#1-what-information-do-we-collect)"
+
+| Category | Examples | Collected
+|---|---|---
+| A. Identifiers | Contact details, such as real name, alias, postal address, telephone or mobile contact number, unique personal identifier, online identifier, Internet Protocol address, email address, and account name | YES
+| B. Personal information as defined in the California Customer Records statute | Name, contact information, education, employment, employment history, and financial information | YES
+| C. Protected classification characteristics under state or federal law | Gender, age, date of birth, race and ethnicity, national origin, marital status, and other demographic data | NO
+| D. Commercial information | Transaction information, purchase history, financial details, and payment information | NO
+| E. Biometric information | Fingerprints and voiceprints | NO
+| F. Internet or other similar network activity | Browsing history, search history, online behavior, interest data, and interactions with our | NO
+| G. Geolocation data | Device location | NO
+| H. Audio, electronic, sensory, or similar information | Images and audio, video or call recordings created in connection with our business activiti | NO
+| I. Professional or employment-related information | Business contact details in order to provide you our Services at a business level or job title, work history, and professional qualifications if you apply for a job with us | NO
+| J. Education Information | Student records and directory information | NO
+| K. Inferences drawn from collected personal information | Inferences drawn from any of the collected personal information listed above to create a profile or summary about, for example, an individual’s preferences and characteristics | NO
+| L. Sensitive personal Information |  | NO
+
+We may also collect other personal information outside of these categories through instances where you interact with us in person, online, or by phone or mail in the context of:
+
+* Receiving help through our customer support channels;
+* Participation in customer surveys or contests; and
+* Facilitation in the delivery of our Services and to respond to your inquiries.
+
+We will use and retain the collected personal information as needed to provide the Services or for:
+
+* Category A - As long as the user has an account with us
+* Category B - As long as the user has an account with us
+
+### Sources of Personal Information
+
+Learn more about the sources of personal information we collect in "[WHAT INFORMATION DO WE COLLECT?](#1-what-information-do-we-collect)"
+
+
+### How We Use and Share Personal Information
+
+Learn more about how we use your personal information in the section, "[HOW DO WE PROCESS YOUR INFORMATION?](#2-how-do-we-process-your-information)"
+
+<strong>Will your information be shared with anyone else?</strong>
+
+We may disclose your personal information with our service providers pursuant to a written contract between us and each service provider. Learn more about how we disclose personal information to in the section, "[WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?](#4-when-and-with-whom-do-we-share-your-personal-information)"
+
+We may use your personal information for our own business purposes, such as for undertaking internal research for technological development and demonstration. This is not considered to be "selling" of your personal information.
+
+We have not disclosed, sold, or shared any personal information to third parties for a business or commercial purpose in the preceding twelve (12) months. We will not sell or share personal information in the future belonging to website visitors, users, and other consumers.
+
+### Your Rights
+
+You have rights under certain US state data protection laws. However, these rights are not absolute, and in certain cases, we may decline your request as permitted by law. These rights include:
+
+* <strong>Right to know</strong> whether or not we are processing your personal data
+* <strong>Right to access</strong> your personal data
+* <strong>Right to correct</strong> inaccuracies in your personal data
+* <strong>Right to request</strong> the deletion of your personal data
+* <strong>Right to obtain a copy</strong> of the personal data you previously shared with us
+* <strong>Right to non-discrimination</strong> for exercising your rights
+* <strong>Right to opt out</strong> of the processing of your personal data if it is used for targeted advertising (or sharing as defined under California’s privacy law), the sale of personal data, or profiling in furtherance of decisions that produce legal or similarly significant effects ("profiling")
+
+Depending upon the state where you live, you may also have the following rights:
+
+* Right to access the categories of personal data being processed (as permitted by applicable law, including the privacy law in Minnesota)
+* Right to obtain a list of the categories of third parties to which we have disclosed personal data (as permitted by applicable law, including the privacy law in California, Delaware, and Maryland)
+* Right to obtain a list of specific third parties to which we have disclosed personal data (as permitted by applicable law, including the privacy law in Minnesota and Oregon)
+* Right to review, understand, question, and correct how personal data has been profiled (as permitted by applicable law, including the privacy law in Minnesota)
+* Right to limit use and disclosure of sensitive personal data (as permitted by applicable law, including the privacy law in California)
+* Right to opt out of the collection of sensitive data and personal data collected through the operation of a voice or facial recognition feature (as permitted by applicable law, including the privacy law in Florida)
+
+### How to Exercise Your Rights
+
+</strong>To exercise these rights, you can contact us by visiting <a href="https://custcodian.dev/about/" target="_blank">https://custcodian.dev/about/</a>, by emailing us at privacy@custcodian.dev, or by referring to the contact details at the bottom of this document.
+
+
+We will honor your opt-out preferences if you enact the <a href="https://globalprivacycontrol.org/" rel="noopener noreferrer" target="_blank">Global Privacy Control</a> (GPC) opt-out signal on your browser.
+
+Under certain US state data protection laws, you can designate an authorized agent to make a request on your behalf. We may deny a request from an authorized agent that does not submit proof that they have been validly authorized to act on your behalf in accordance with applicable laws.
+
+### Request Verification
+
+Upon receiving your request, we will need to verify your identity to determine you are the same person about whom we have the information in our system. We will only use personal information provided in your request to verify your identity or authority to make the request. However, if we cannot verify your identity from the information already maintained by us, we may request that you provide additional information for the purposes of verifying your identity and for security or fraud-prevention purposes.
+
+If you submit the request through an authorized agent, we may need to collect additional information to verify your identity before processing your request and the agent will need to provide a written and signed permission from you to submit such request on your behalf.
+
+### Appeals
+
+Under certain US state data protection laws, if we decline to take action regarding your request, you may appeal our decision by emailing us at privacy@custcodian.dev. We will inform you in writing of any action taken or not taken in response to the appeal, including a written explanation of the reasons for the decisions. If your appeal is denied, you may submit a complaint to your state attorney general.
+
+### California "Shine The Light" Law
+
+California Civil Code Section 1798.83, also known as the "Shine The Light" law, permits our users who are California residents to request and obtain from us, once a year and free of charge, information about categories of personal information (if any) we disclosed to third parties for direct marketing purposes and the names and addresses of all third parties with which we shared personal information in the immediately preceding calendar year. If you are a California resident and would like to make such a request, please submit your request in writing to us by using the contact details provided in the section "[HOW CAN YOU CONTACT US ABOUT THIS NOTICE?](#14-how-can-you-contact-us-about-this-notice)"
+
+## 13. DO WE MAKE UPDATES TO THIS NOTICE?
+
+<em><strong>In Short:</strong> Yes, we will update this notice as necessary to stay compliant with relevant laws.</em>
+
+We may update this Privacy Notice from time to time. The updated version will be indicated by an updated "Revised" date at the top of this Privacy Notice. If we make material changes to this Privacy Notice, we may notify you either by prominently posting a notice of such changes or by directly sending you a notification. We encourage you to review this Privacy Notice frequently to be informed of how we are protecting your information.
+
+## 14. HOW CAN YOU CONTACT US ABOUT THIS NOTICE?
+
+If you have questions or comments about this notice, you may contact our Data Protection Officer (DPO) by email at privacy@custcodian.dev, or contact us by post at:
+
+Custcodian LLC \
+Data Protection Officer \
+600 1st Ave \
+Suite 410 \
+Seattle, WA 98104 \
+United States
+
+## 15. HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?
+
+You have the right to request access to the personal information we collect from you, details about how we have processed it, correct inaccuracies, or delete your personal information. You may also have the right to withdraw your consent to our processing of your personal information. These rights may be limited in some circumstances by applicable law. To request to review, update, or delete your personal information, please visit: https://custcodian.dev/about/.


### PR DESCRIPTION
From https://app.termly.io/dashboard/website/728ee22d-3291-4a8c-a5cc-8b6559d1dc69/privacy-policy  ("Generate a SaaS privacy policy from template"), and then converted terrible HTML to markdown.

I also reviewed https://payproglobal.com/wp-content/uploads/2024/09/SaaS-Privacy-Policy-Template.pdf., but the (free) Termly fill-out-a-form results seemed mostly better.  I did need to correct one or two fill-in-the-blanks cases around usage (particularly "Enable Minder to manage your software assets on a third-party site").