### PR TITLE
Fix plausible javascript linkage

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,10 @@ copyright: |
     </div>
 
 plugins:
-- privacy
+- privacy:
+    # Temporarily exclude plausible.io scripts which are GDPR-compliant (until we can set up proxies)
+    assets_exclude:
+      - plausible.io/*
 - material-plausible
 - redirects:
     redirect_maps:


### PR DESCRIPTION
The `privacy` plugin copies the `plausible.io` scripts to local storage, but the `plausible.io` scripts attempt to assemble the `/api/events` endpoint from the script source location, which causes the reporting to fail.



* **Fix plausible.io script tags with privacy plugin**



