### PR TITLE
Attempt 2 to fix tracking with plausible.io

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,9 @@ extra:
   analytics:
     provider: plausible
     domain: custcodian.dev
-    # TODO: set up custom domain proxy
+    # TODO: set up custom domain proxy.  In the meantime, we need to set
+    # `api` since the `privacy` plugin will download the JS
+    api: "https://plausible.io/api/event"
 
 not_in_nav: /about
 
@@ -54,10 +56,7 @@ copyright: |
     </div>
 
 plugins:
-- privacy:
-    # Temporarily exclude plausible.io scripts which are GDPR-compliant (until we can set up proxies)
-    assets_exclude:
-      - plausible.io/*
+- privacy
 - material-plausible
 - redirects:
     redirect_maps:


### PR DESCRIPTION
It turns out that the `assets\_exclude` plugin is sponsors-only, so switch to using the `api` parameter on analytics for reporting the events.

