### PR TITLE
Only publish from 'main' branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,8 @@ name: Publish site
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
See https://github.com/custcodian/website/actions/runs/16812709357/job/47621793774?pr=9 for an example that shouldn't have been run (at least permissions stopped it).

